### PR TITLE
fix: solved the WARNING that was happening in the hooks test

### DIFF
--- a/packages/web/src/fixtures/dev-kit/hooks.spec.ts
+++ b/packages/web/src/fixtures/dev-kit/hooks.spec.ts
@@ -8,6 +8,7 @@ import {
 import useSWR from 'swr'
 import { toNaturalNumber } from 'src/fixtures/utility'
 import { withdrawHolderAmount } from './client'
+import { message } from 'antd'
 
 jest.mock('swr')
 jest.mock('src/fixtures/utility')
@@ -106,12 +107,27 @@ describe('dev-kit hooks', () => {
 
   describe('useWithdrawHolderReward', () => {
     test('success withdraw', async () => {
-      ;(withdrawHolderAmount as jest.Mock).mockImplementation(async () => true)
-      const { result } = renderHook(() => useWithdrawHolderReward())
+      const { result, waitForNextUpdate } = renderHook(() => useWithdrawHolderReward())
+      ;(withdrawHolderAmount as jest.Mock).mockResolvedValue(true)
       act(() => {
         result.current.withdraw('property-address')
       })
+      await waitForNextUpdate()
       expect(result.current.error).toBe(undefined)
+      expect(result.current.isLoading).toBe(false)
+    })
+
+    test('failure withdraw', async () => {
+      const error = new Error('error')
+      const { result, waitForNextUpdate } = renderHook(() => useWithdrawHolderReward())
+      ;(withdrawHolderAmount as jest.Mock).mockRejectedValue(error)
+      message.error = jest.fn(() => {}) as any
+      act(() => {
+        result.current.withdraw('property-address')
+      })
+      await waitForNextUpdate()
+      expect(result.current.error).toBe(error)
+      expect(result.current.isLoading).toBe(false)
     })
   })
 })

--- a/packages/web/src/fixtures/dev-kit/hooks.spec.ts
+++ b/packages/web/src/fixtures/dev-kit/hooks.spec.ts
@@ -1,4 +1,4 @@
-import { renderHook } from '@testing-library/react-hooks'
+import { renderHook, act } from '@testing-library/react-hooks'
 import {
   useGetTotalRewardsAmount,
   useGetTotalStakingAmount,
@@ -107,13 +107,11 @@ describe('dev-kit hooks', () => {
   describe('useWithdrawHolderReward', () => {
     test('success withdraw', async () => {
       ;(withdrawHolderAmount as jest.Mock).mockImplementation(async () => true)
-      const {
-        result: {
-          current: { error, withdraw }
-        }
-      } = renderHook(() => useWithdrawHolderReward())
-      await withdraw('property-address')
-      expect(error).toBe(undefined)
+      const { result } = renderHook(() => useWithdrawHolderReward())
+      act(() => {
+        result.current.withdraw('property-address')
+      })
+      expect(result.current.error).toBe(undefined)
     })
   })
 })

--- a/packages/web/src/fixtures/dev-kit/hooks.ts
+++ b/packages/web/src/fixtures/dev-kit/hooks.ts
@@ -19,6 +19,7 @@ export const useWithdrawHolderReward = () => {
   const [error, setError] = useState<Error>()
   const withdraw = useCallback(async (propertyAddress: string) => {
     setIsLoading(true)
+    setError(undefined)
     return withdrawHolderAmount(propertyAddress)
       .then(() => {
         setIsLoading(false)

--- a/packages/web/src/fixtures/dev-kit/hooks.ts
+++ b/packages/web/src/fixtures/dev-kit/hooks.ts
@@ -3,7 +3,7 @@ import { SWRCachePath } from './cache-path'
 import { UnwrapFunc, toNaturalNumber } from 'src/fixtures/utility'
 import useSWR from 'swr'
 import { message } from 'antd'
-import { useState } from 'react'
+import { useState, useCallback } from 'react'
 
 export const useGetTotalRewardsAmount = (propertyAddress: string) => {
   const { data, error } = useSWR<UnwrapFunc<typeof getRewardsAmount>, Error>(
@@ -16,19 +16,19 @@ export const useGetTotalRewardsAmount = (propertyAddress: string) => {
 
 export const useWithdrawHolderReward = () => {
   const [isLoading, setIsLoading] = useState<boolean>(false)
-  const [error, setError] = useState<Error | undefined>(undefined)
-
-  const withdraw = async (propertyAddress: string) => {
+  const [error, setError] = useState<Error>()
+  const withdraw = useCallback(async (propertyAddress: string) => {
     setIsLoading(true)
-    setError(undefined)
     return withdrawHolderAmount(propertyAddress)
-      .then(() => setIsLoading(false))
+      .then(() => {
+        setIsLoading(false)
+      })
       .catch(err => {
         setError(err)
         message.error(err.message)
         setIsLoading(false)
       })
-  }
+  }, [])
 
   return { withdraw, isLoading, error }
 }


### PR DESCRIPTION
## Proposed Changes

- As with the title

## Implementation

- Implemented the hooks test using `act`
- Changed the hooks value to return using `useCallBack`

### FYI
- https://github.com/testing-library/react-hooks-testing-library/blob/master/docs/usage/advanced-hooks.md#async