### PR TITLE
feat: use statistics component for outline organisms

### DIFF
--- a/packages/web/src/__mocks__/window/matchMedia.mock.ts
+++ b/packages/web/src/__mocks__/window/matchMedia.mock.ts
@@ -1,0 +1,13 @@
+export default Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: jest.fn().mockImplementation(query => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: jest.fn(), // deprecated
+    removeListener: jest.fn(), // deprecated
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn(),
+    dispatchEvent: jest.fn()
+  }))
+})

--- a/packages/web/src/components/organisms/PossessionOutline/__snapshots__/index.spec.tsx.snap
+++ b/packages/web/src/components/organisms/PossessionOutline/__snapshots__/index.spec.tsx.snap
@@ -9,15 +9,141 @@ exports[`PossessionOutline Snapshot 1`] = `
       <div
         class="ant-card-body"
       >
-        <div>
-          total staking amount: 
-          10000
-           DEV
-        </div>
-        <div>
-          Your staking amount: 
-          5000
-           DEV
+        <div
+          class="ant-row"
+        >
+          <div
+            class="ant-col ant-col-6"
+          >
+            <div
+              class="ant-statistic"
+            >
+              <div
+                class="ant-statistic-title"
+              >
+                Total Staking Amount
+              </div>
+              <div
+                class="ant-statistic-content"
+              >
+                <span
+                  class="ant-statistic-content-value"
+                >
+                  <span
+                    class="ant-statistic-content-value-int"
+                  >
+                    
+                    10,000
+                  </span>
+                  
+                </span>
+                <span
+                  class="ant-statistic-content-suffix"
+                >
+                  DEV
+                </span>
+              </div>
+            </div>
+          </div>
+          <div
+            class="ant-col ant-col-6"
+          >
+            <div
+              class="ant-statistic"
+            >
+              <div
+                class="ant-statistic-title"
+              >
+                Your Staking Amount
+              </div>
+              <div
+                class="ant-statistic-content"
+              >
+                <span
+                  class="ant-statistic-content-value"
+                >
+                  <span
+                    class="ant-statistic-content-value-int"
+                  >
+                    
+                    5,000
+                  </span>
+                  
+                </span>
+                <span
+                  class="ant-statistic-content-suffix"
+                >
+                  DEV
+                </span>
+              </div>
+            </div>
+          </div>
+          <div
+            class="ant-col ant-col-6"
+          >
+            <div
+              class="ant-statistic"
+            >
+              <div
+                class="ant-statistic-title"
+              >
+                Average Interest Rate
+              </div>
+              <div
+                class="ant-statistic-content"
+              >
+                <span
+                  class="ant-statistic-content-value"
+                >
+                  <span
+                    class="ant-statistic-content-value-int"
+                  >
+                    
+                    5,000
+                  </span>
+                  
+                </span>
+                <span
+                  class="ant-statistic-content-suffix"
+                >
+                  %
+                </span>
+              </div>
+            </div>
+          </div>
+          <div
+            class="ant-col ant-col-6"
+          >
+            <div
+              class="ant-statistic"
+            >
+              <div
+                class="ant-statistic-title"
+              >
+                Total Rewards
+              </div>
+              <div
+                class="ant-statistic-content"
+              >
+                <span
+                  class="ant-statistic-content-value"
+                >
+                  <span
+                    class="ant-statistic-content-value-int"
+                  >
+                    
+                    5,000
+                  </span>
+                  
+                </span>
+                <span
+                  class="ant-statistic-content-suffix"
+                >
+                  DEV
+                </span>
+              </div>
+            </div>
+          </div>
         </div>
       </div>
     </div>

--- a/packages/web/src/components/organisms/PossessionOutline/index.spec.tsx
+++ b/packages/web/src/components/organisms/PossessionOutline/index.spec.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { render } from '@testing-library/react'
 import { PossessionOutline } from '.'
+import 'src/__mocks__/window/matchMedia.mock'
 
 jest.mock('src/fixtures/dev-kit/hooks')
 

--- a/packages/web/src/components/organisms/PossessionOutline/index.tsx
+++ b/packages/web/src/components/organisms/PossessionOutline/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Card } from 'antd'
+import { Card, Statistic, Row, Col } from 'antd'
 import { useGetTotalStakingAmount, useGetMyStakingAmount } from 'src/fixtures/dev-kit/hooks'
 
 interface Props {
@@ -12,8 +12,32 @@ export const PossessionOutline = ({ propertyAddress }: Props) => {
 
   return (
     <Card>
-      {totalStakingAmount && <div>total staking amount: {totalStakingAmount.dp(1).toNumber()} DEV</div>}
-      {myStakingAmount && <div>Your staking amount: {myStakingAmount.dp(1).toNumber()} DEV</div>}
+      <Row>
+        <Col span={6}>
+          <Statistic
+            title="Total Staking Amount"
+            value={totalStakingAmount && totalStakingAmount.dp(1).toNumber()}
+            suffix="DEV"
+          />
+        </Col>
+        <Col span={6}>
+          <Statistic
+            title="Your Staking Amount"
+            value={myStakingAmount && myStakingAmount.dp(1).toNumber()}
+            suffix="DEV"
+          />
+        </Col>
+        <Col span={6}>
+          <Statistic
+            title="Average Interest Rate"
+            value={myStakingAmount && myStakingAmount.dp(1).toNumber()}
+            suffix="%"
+          />
+        </Col>
+        <Col span={6}>
+          <Statistic title="Total Rewards" value={myStakingAmount && myStakingAmount.dp(1).toNumber()} suffix="DEV" />
+        </Col>
+      </Row>
     </Card>
   )
 }


### PR DESCRIPTION
## Proposed Changes

- use static component for outline organisms
- add matchMedia mock for antdesign snapshot

## Implementation

![スクリーンショット 2020-04-17 5 09 51](https://user-images.githubusercontent.com/16770233/79501944-dfa0cc00-8069-11ea-8f8b-fc480ff2953b.png)
