### PR TITLE
fix: change global theme

### DIFF
--- a/packages/web/next.config.js
+++ b/packages/web/next.config.js
@@ -6,7 +6,7 @@ const withCss = require('@zeit/next-css')
 
 const themeVariables = lessToJS(fs.readFileSync(path.resolve(__dirname, './src/assets/antd-custom.less'), 'utf8'))
 if (typeof require !== 'undefined') {
-  require.extensions['.less'] = (file) => {}
+  require.extensions['.less'] = file => {}
 }
 
 module.exports = withCss(
@@ -24,12 +24,12 @@ module.exports = withCss(
               callback()
             }
           },
-          ...(typeof origExternals[0] === 'function' ? [] : origExternals),
+          ...(typeof origExternals[0] === 'function' ? [] : origExternals)
         ]
 
         config.module.rules.unshift({
           test: antStyles,
-          use: 'null-loader',
+          use: 'null-loader'
         })
       }
 
@@ -55,10 +55,10 @@ module.exports = withCss(
     },
     lessLoaderOptions: {
       javascriptEnabled: true,
-      modifyVars: themeVariables, // make your antd custom effective
+      modifyVars: themeVariables // make your antd custom effective
     },
     env: {
-      END_POINT: process.env.END_POINT || 'http://localhost:3003/graphql',
-    },
+      END_POINT: process.env.END_POINT || 'http://localhost:3003/graphql'
+    }
   })
 )

--- a/packages/web/src/assets/antd-custom.less
+++ b/packages/web/src/assets/antd-custom.less
@@ -11,7 +11,4 @@
 @border-radius-base: 4px; // major border radius
 @border-color-base: #d9d9d9; // major border color
 @box-shadow-base: 0 2px 8px rgba(0, 0, 0, 0.15); // major shadow for layers
-
-// checkbox
-@checkbox-size: 24px;
 @font-family: Segoe UI;

--- a/packages/web/src/assets/antd-custom.less
+++ b/packages/web/src/assets/antd-custom.less
@@ -1,27 +1,17 @@
-@primary-color: #f0414c;
-@layout-header-height: 51px;
-@layout-header-padding: 0px 0px;
-@layout-header-background: #f8f8f8;
-@layout-body-background: #ffffff;
-@layout-footer-padding: 0px;
-@border-radius-base: 2px;
-// radio button
-@radio-button-checked-bg: rgba(240, 65, 76, 0.1);
-@radio-button-color: #303034;
-
-// button
-@border-color-base: #f0414c;
-@btn-default-color: #f0414c;
-@btn-border-radius-base: 5px;
-@btn-disable-color: #ffffff;
-@btn-disable-bg: rgba(240, 65, 76, 0.5);
-@btn-disable-border: rgba(240, 65, 76, 0.1);
-
-// input
-@input-color: '#000000';
-@input-border-color: '#d9d9d9';
+@primary-color: #2f80ed; // primary color for all components
+@link-color: #2f80ed; // link color
+@success-color: #52c41a; // success state color
+@warning-color: #faad14; // warning state color
+@error-color: #f5222d; // error state color
+@font-size-base: 14px; // major text font size
+@heading-color: rgba(0, 0, 0, 0.85); // heading text color
+@text-color: rgba(0, 0, 0, 0.65); // major text color
+@text-color-secondary: rgba(0, 0, 0, 0.45); // secondary text color
+@disabled-color: rgba(0, 0, 0, 0.25); // disable state color
+@border-radius-base: 4px; // major border radius
+@border-color-base: #d9d9d9; // major border color
+@box-shadow-base: 0 2px 8px rgba(0, 0, 0, 0.15); // major shadow for layers
 
 // checkbox
-
 @checkbox-size: 24px;
-@font-family: Noto Sans JP, Roboto, sans-serif;
+@font-family: Segoe UI;


### PR DESCRIPTION
## Proposed Changes

- Changed global theme to match Figma's design
- Remove unnecessary theme options

Figma's design has no `strength` in text (all of them have same `font-size`). I tried to fit it in there, but I thought it would be better to modify the design, so I left it at that.

![スクリーンショット 2020-04-18 0 06 51](https://user-images.githubusercontent.com/16770233/79585468-ce5bcc00-810a-11ea-9039-ec381c77a992.png)


## Implementation

- Changed global theme to match Figma's design